### PR TITLE
Adds "how to use this project" to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,25 @@
 * Dark/light mode
 * Color variations
 
+## How to use this project
+
 [![tailblocks](https://github.com/mertjf/tailblocks/blob/master/public/preview.gif)](https://mertjf.github.io/tailblocks)
+
+This project provides multiple templates built using [Tailwind
+CSS](https://tailwindcss.com/) that you can use in your own projects. This
+project is not a dependency that you add to your project, but instead provides
+you with HTML that you can easily copy and paste into your own project.
+
+To use the project:
+
+1. Go to the [demo site](https://mertjf.github.io/tailblocks/)
+1. Find a template that you would like to use
+1. Select the colorscheme you want with the colorscheme-picker
+1. Select whether you would like to use light or dark mode with the picker
+1. Click the "View Code" button
+1. Copy/paste into your project
+1. 🎉
+
 
 ## License
 


### PR DESCRIPTION
Since this project is not a traditional dependency [it may not be
obvious](https://github.com/mertJF/tailblocks/issues/14) how it is
expected to be used.

This commit adds a section to the README that can hopefully make it
easier to know how to use this project.

I tried to base this on the answer given [here](https://github.com/mertJF/tailblocks/issues/14#issuecomment-635511374).  