### PR TITLE
Addition of Team D page

### DIFF
--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -144,10 +144,12 @@ import DarkStepC from './step/dark/c';
 import LightTeamA from './team/light/a';
 import LightTeamB from './team/light/b';
 import LightTeamC from './team/light/c';
+import LightTeamD from './team/light/d';
 
 import DarkTeamA from './team/dark/a';
 import DarkTeamB from './team/dark/b';
 import DarkTeamC from './team/dark/c';
+import DarkTeamD from './team/dark/d';
 
 import LightTestimonialA from './testimonial/light/a';
 import LightTestimonialB from './testimonial/light/b';
@@ -245,7 +247,8 @@ export default function getBlock({theme = 'indigo', darkMode = false}) {
     Team: {
       TeamA: darkMode ? <DarkTeamA theme={theme} /> : <LightTeamA theme={theme} />,
       TeamB: darkMode ? <DarkTeamB theme={theme} /> : <LightTeamB theme={theme} />,
-      TeamC: darkMode ? <DarkTeamC theme={theme} /> : <LightTeamC theme={theme} />
+      TeamC: darkMode ? <DarkTeamC theme={theme} /> : <LightTeamC theme={theme} />,
+      TeamD: darkMode ? <DarkTeamD theme={theme} /> : <LightTeamD theme={theme} />
     },
     Testimonial: {
       TestimonialA: darkMode ? <DarkTestimonialA theme={theme} /> : <LightTestimonialA theme={theme} />,

--- a/src/blocks/team/dark/d.js
+++ b/src/blocks/team/dark/d.js
@@ -18,7 +18,7 @@ function DarkTeamD(props) {
 
         <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-800 sm:flex-row flex-col">
           <div
-            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full text-${props.theme}-400 bg-gray-800 flex-shrink-0`}
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full  bg-gray-800 flex-shrink-0`}
           >
             <img
               alt="team"
@@ -35,7 +35,7 @@ function DarkTeamD(props) {
               vaporware photo booth fam.
             </p>
             <span className="inline-flex">
-              <a href className="text-gray-700">
+              <a href className="text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -48,7 +48,7 @@ function DarkTeamD(props) {
                   <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
                 </svg>
               </a>
-              <a href className="ml-2 text-gray-700">
+              <a href className="ml-2 text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -61,7 +61,7 @@ function DarkTeamD(props) {
                   <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
                 </svg>
               </a>
-              <a href className="ml-2 text-gray-700">
+              <a href className="ml-2 text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -80,7 +80,7 @@ function DarkTeamD(props) {
 
         <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-800 sm:flex-row flex-col">
           <div
-            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full text-${props.theme}-400 bg-gray-800 flex-shrink-0`}
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full  bg-gray-800 flex-shrink-0`}
           >
             <img
               alt="team"
@@ -98,7 +98,7 @@ function DarkTeamD(props) {
               vaporware photo booth fam.
             </p>
             <span className="inline-flex">
-              <a href className="text-gray-700">
+              <a href className="text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -111,7 +111,7 @@ function DarkTeamD(props) {
                   <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
                 </svg>
               </a>
-              <a href className="ml-2 text-gray-700">
+              <a href className="ml-2 text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -124,7 +124,7 @@ function DarkTeamD(props) {
                   <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
                 </svg>
               </a>
-              <a href className="ml-2 text-gray-700">
+              <a href className="ml-2 text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -143,7 +143,7 @@ function DarkTeamD(props) {
 
         <div className="flex items-center lg:w-3/5 mx-auto sm:flex-row flex-col">
           <div
-            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full text-${props.theme}-400 bg-gray-800 flex-shrink-0`}
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full  bg-gray-800 flex-shrink-0`}
           >
             <img
               alt="team"
@@ -161,7 +161,7 @@ function DarkTeamD(props) {
               vaporware photo booth fam.
             </p>
             <span className="inline-flex">
-              <a href className="text-gray-700">
+              <a href className="text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -174,7 +174,7 @@ function DarkTeamD(props) {
                   <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
                 </svg>
               </a>
-              <a href className="ml-2 text-gray-700">
+              <a href className="ml-2 text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"
@@ -187,7 +187,7 @@ function DarkTeamD(props) {
                   <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
                 </svg>
               </a>
-              <a href className="ml-2 text-gray-700">
+              <a href className="ml-2 text-gray-500">
                 <svg
                   fill="none"
                   stroke="currentColor"

--- a/src/blocks/team/dark/d.js
+++ b/src/blocks/team/dark/d.js
@@ -1,0 +1,219 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function DarkTeamD(props) {
+  return (
+    <section className="text-gray-400 bg-gray-900 body-font">
+      <div className="container px-5 py-24 mx-auto">
+        <div className="flex flex-col text-center w-full mb-20">
+          <h1 className="sm:text-3xl text-2xl font-medium title-font mb-4 text-white">
+            Our Team
+          </h1>
+          <p className="lg:w-2/3 mx-auto leading-relaxed text-base">
+            Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical
+            gentrify, subway tile poke farm-to-table. Franzen you probably
+            haven&apos;t heard of them.
+          </p>
+        </div>
+
+        <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-800 sm:flex-row flex-col">
+          <div
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full text-${props.theme}-400 bg-gray-800 flex-shrink-0`}
+          >
+            <img
+              alt="team"
+              className=" bg-gray-100 object-cover object-center flex-shrink-0 rounded-full"
+              src="https://dummyimage.com/200x200"
+            />
+          </div>
+          <div className="flex-grow sm:text-left text-center mt-6 sm:mt-0">
+            <h2 className="text-white text-lg title-font font-medium mb-2">
+              Holden Caulfield <span className="font-light">| UI Designer</span>
+            </h2>
+            <p className="leading-relaxed text-base mb-4">
+              DIY tote bag drinking vinegar cronut adaptogen squid fanny pack
+              vaporware photo booth fam.
+            </p>
+            <span className="inline-flex">
+              <a href className="text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </a>
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-800 sm:flex-row flex-col">
+          <div
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full text-${props.theme}-400 bg-gray-800 flex-shrink-0`}
+          >
+            <img
+              alt="team"
+              className=" bg-gray-100 object-cover object-center flex-shrink-0 rounded-full"
+              src="https://dummyimage.com/200x200"
+            />
+          </div>
+          <div className="flex-grow sm:text-left text-center mt-6 sm:mt-0">
+            <h2 className="text-white text-lg title-font font-medium mb-2">
+              Atticus Finch{" "}
+              <span className="font-light">| Product Manager</span>
+            </h2>
+            <p className="leading-relaxed text-base mb-4">
+              DIY tote bag drinking vinegar cronut adaptogen squid fanny pack
+              vaporware photo booth fam.
+            </p>
+            <span className="inline-flex">
+              <a href className="text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </a>
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center lg:w-3/5 mx-auto sm:flex-row flex-col">
+          <div
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full text-${props.theme}-400 bg-gray-800 flex-shrink-0`}
+          >
+            <img
+              alt="team"
+              className=" bg-gray-100 object-cover object-center flex-shrink-0 rounded-full"
+              src="https://dummyimage.com/200x200"
+            />
+          </div>
+          <div className="flex-grow sm:text-left text-center mt-6 sm:mt-0">
+            <h2 className="text-white text-lg title-font font-medium mb-2">
+              Alper Kamu{" "}
+              <span className="font-light">| Software Developer</span>
+            </h2>
+            <p className="leading-relaxed text-base mb-4">
+              DIY tote bag drinking vinegar cronut adaptogen squid fanny pack
+              vaporware photo booth fam.
+            </p>
+            <span className="inline-flex">
+              <a href className="text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-700">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </a>
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+DarkTeamD.defaultProps = {
+  theme: "indigo",
+};
+
+DarkTeamD.propTypes = {
+  theme: PropTypes.string.isRequired,
+};
+
+export default DarkTeamD;

--- a/src/blocks/team/light/d.js
+++ b/src/blocks/team/light/d.js
@@ -1,0 +1,219 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function LightTeamD(props) {
+  return (
+    <section className="text-gray-600 body-font">
+      <div className="container px-5 py-24 mx-auto">
+        <div className="flex flex-col text-center w-full mb-20">
+          <h1 className="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">
+            Our Team
+          </h1>
+          <p className="lg:w-2/3 mx-auto leading-relaxed text-base">
+            Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical
+            gentrify, subway tile poke farm-to-table. Franzen you probably
+            haven&apos;t heard of them.
+          </p>
+        </div>
+
+        <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-200 sm:flex-row flex-col">
+          <div
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full bg-${props.theme}-100 text-${props.theme}-500 flex-shrink-0`}
+          >
+            <img
+              alt="team"
+              className=" bg-gray-100 object-cover object-center flex-shrink-0 rounded-full"
+              src="https://dummyimage.com/200x200"
+            />
+          </div>
+          <div className="flex-grow sm:text-left text-center mt-6 sm:mt-0">
+            <h2 className="text-gray-900 text-lg title-font font-medium mb-2">
+              Holden Caulfield <span className="font-light">| UI Designer</span>
+            </h2>
+            <p className="leading-relaxed text-base mb-4">
+              DIY tote bag drinking vinegar cronut adaptogen squid fanny pack
+              vaporware photo booth fam.
+            </p>
+            <span className="inline-flex">
+              <a href className="text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </a>
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-200 sm:flex-row flex-col">
+          <div
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full bg-${props.theme}-100 text-${props.theme}-500 flex-shrink-0`}
+          >
+            <img
+              alt="team"
+              className=" bg-gray-100 object-cover object-center flex-shrink-0 rounded-full"
+              src="https://dummyimage.com/200x200"
+            />
+          </div>
+          <div className="flex-grow sm:text-left text-center mt-6 sm:mt-0">
+            <h2 className="text-gray-900 text-lg title-font font-medium mb-2">
+              Atticus Finch{" "}
+              <span className="font-light">| Product Manager</span>
+            </h2>
+            <p className="leading-relaxed text-base mb-4">
+              DIY tote bag drinking vinegar cronut adaptogen squid fanny pack
+              vaporware photo booth fam.
+            </p>
+            <span className="inline-flex">
+              <a href className="text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </a>
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center lg:w-3/5 mx-auto sm:flex-row flex-col">
+          <div
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full bg-${props.theme}-100 text-${props.theme}-500 flex-shrink-0`}
+          >
+            <img
+              alt="team"
+              className=" bg-gray-100 object-cover object-center flex-shrink-0 rounded-full"
+              src="https://dummyimage.com/200x200"
+            />
+          </div>
+          <div className="flex-grow sm:text-left text-center mt-6 sm:mt-0">
+            <h2 className="text-gray-900 text-lg title-font font-medium mb-2">
+              Alper Kamu{" "}
+              <span className="font-light">| Software Developer</span>
+            </h2>
+            <p className="leading-relaxed text-base mb-4">
+              DIY tote bag drinking vinegar cronut adaptogen squid fanny pack
+              vaporware photo booth fam.
+            </p>
+            <span className="inline-flex">
+              <a href className="text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z" />
+                </svg>
+              </a>
+              <a href className="ml-2 text-gray-500">
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </a>
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+LightTeamD.defaultProps = {
+  theme: "indigo",
+};
+
+LightTeamD.propTypes = {
+  theme: PropTypes.string.isRequired,
+};
+
+export default LightTeamD;

--- a/src/blocks/team/light/d.js
+++ b/src/blocks/team/light/d.js
@@ -18,7 +18,7 @@ function LightTeamD(props) {
 
         <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-200 sm:flex-row flex-col">
           <div
-            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full bg-${props.theme}-100 text-${props.theme}-500 flex-shrink-0`}
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full flex-shrink-0`}
           >
             <img
               alt="team"
@@ -80,7 +80,7 @@ function LightTeamD(props) {
 
         <div className="flex items-center lg:w-3/5 mx-auto border-b pb-5 mb-5 border-gray-200 sm:flex-row flex-col">
           <div
-            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full bg-${props.theme}-100 text-${props.theme}-500 flex-shrink-0`}
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full  flex-shrink-0`}
           >
             <img
               alt="team"
@@ -143,7 +143,7 @@ function LightTeamD(props) {
 
         <div className="flex items-center lg:w-3/5 mx-auto sm:flex-row flex-col">
           <div
-            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full bg-${props.theme}-100 text-${props.theme}-500 flex-shrink-0`}
+            className={`sm:w-32 sm:h-32 h-20 w-20 sm:mr-10 inline-flex items-center justify-center rounded-full flex-shrink-0`}
           >
             <img
               alt="team"

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -73,6 +73,7 @@ import StepC from './step/c';
 import TeamA from './team/a';
 import TeamB from './team/b';
 import TeamC from './team/c';
+import TeamD from './team/d';
 
 import TestimonialA from './testimonial/a';
 import TestimonialB from './testimonial/b';
@@ -166,7 +167,8 @@ export default function getIcons() {
     Team: {
       TeamA: <TeamA />,
       TeamB: <TeamB />,
-      TeamC: <TeamC />
+      TeamC: <TeamC />,
+      TeamD: <TeamD />
     },
     Testimonial: {
       TestimonialA: <TestimonialA />,

--- a/src/icons/team/d.js
+++ b/src/icons/team/d.js
@@ -1,0 +1,69 @@
+import React from "react";
+
+function TeamD() {
+  return (
+    <svg viewBox="0 0 266 150" fill="none">
+      <path fill="var(--solid)" d="M0 0h266v150H0z" />
+      <circle cx={88} cy={28} r={8} fill="var(--main-200)" />
+      <path
+        d="M102 28a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
+        fill="var(--base-500)"
+      />
+      <path
+        d="M102 33a1 1 0 011-1h14a1 1 0 010 2h-14a1 1 0 01-1-1z"
+        fill="var(--main-500)"
+      />
+      <rect
+        x={102}
+        y={21}
+        width={40}
+        height={3}
+        rx={1.5}
+        fill="var(--solid-900)"
+      />
+
+      <circle cx={88} cy={98} r={8} fill="var(--main-200)" />
+      <path
+        d="M102 98a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
+        fill="var(--base-500)"
+      />
+      <path
+        d="M102 103a1 1 0 011-1h14a1 1 0 010 2h-14a1 1 0 01-1-1z"
+        fill="var(--main-500)"
+      />
+      <rect
+        x={102}
+        y={91}
+        width={40}
+        height={3}
+        rx={1.5}
+        fill="var(--solid-900)"
+      />
+
+      <circle cx={178} cy={63} r={8} fill="var(--main-200)" />
+      <path
+        d="M80 63a1 1 0 011-1h68a1 1 0 010 2H81a1 1 0 01-1-1z"
+        fill="var(--base-500)"
+      />
+      <path
+        d="M80 68a1 1 0 011-1h14a1 1 0 110 2H81a1 1 0 01-1-1z"
+        fill="var(--main-500)"
+      />
+      <rect
+        x={80}
+        y={56}
+        width={40}
+        height={3}
+        rx={1.5}
+        fill="var(--solid-900)"
+      />
+
+      <path
+        d="M185.5 45a.5.5 0 010 1h-105a.5.5 0 010-1h105zM185.5 80a.5.5 0 010 1h-105a.5.5 0 010-1h105z"
+        fill="var(--base-400)"
+      />
+    </svg>
+  );
+}
+
+export default TeamD;

--- a/src/icons/team/d.js
+++ b/src/icons/team/d.js
@@ -4,63 +4,71 @@ function TeamD() {
   return (
     <svg viewBox="0 0 266 150" fill="none">
       <path fill="var(--solid)" d="M0 0h266v150H0z" />
-      <circle cx={88} cy={28} r={8} fill="var(--main-200)" />
+
+      <rect
+        x={110}
+        y={20}
+        width={46}
+        height={5}
+        rx={2.5}
+        fill="var(--solid-900)"
+      />
+      <rect x={87} y={29} width={92} height={4} rx={2} fill="var(--base-500)" />
+
+      <circle cx={93} cy={55} r={8} fill="var(--base-200)" />
       <path
-        d="M102 28a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
+        d="M107 55a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
         fill="var(--base-500)"
       />
+
       <path
-        d="M102 33a1 1 0 011-1h14a1 1 0 010 2h-14a1 1 0 01-1-1z"
-        fill="var(--main-500)"
+        d="M107 60a1 1 0 011-1h14a1 1 0 010 2h-14a1 1 0 01-1-1z"
+        fill="var(--base-500)"
       />
+
       <rect
-        x={102}
-        y={21}
+        x={107}
+        y={48}
         width={40}
         height={3}
         rx={1.5}
         fill="var(--solid-900)"
       />
 
-      <circle cx={88} cy={98} r={8} fill="var(--main-200)" />
+      <circle cx={93} cy={85} r={8} fill="var(--base-200)" />
       <path
-        d="M102 98a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
+        d="M107 85a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
         fill="var(--base-500)"
       />
       <path
-        d="M102 103a1 1 0 011-1h14a1 1 0 010 2h-14a1 1 0 01-1-1z"
-        fill="var(--main-500)"
+        d="M107 90a1 1 0 011-1h14a1 1 0 110 2h-14a1 1 0 01-1-1z"
+        fill="var(--base-500)"
       />
       <rect
-        x={102}
-        y={91}
+        x={107}
+        y={78}
         width={40}
         height={3}
         rx={1.5}
         fill="var(--solid-900)"
       />
 
-      <circle cx={178} cy={63} r={8} fill="var(--main-200)" />
+      <circle cx={93} cy={113} r={8} fill="var(--base-200)" />
       <path
-        d="M80 63a1 1 0 011-1h68a1 1 0 010 2H81a1 1 0 01-1-1z"
+        d="M107 113a1 1 0 011-1h68a1 1 0 010 2h-68a1 1 0 01-1-1z"
         fill="var(--base-500)"
       />
       <path
-        d="M80 68a1 1 0 011-1h14a1 1 0 110 2H81a1 1 0 01-1-1z"
-        fill="var(--main-500)"
+        d="M107 118a1 1 0 011-1h14a1 1 0 010 2h-14a1 1 0 01-1-1z"
+        fill="var(--base-500)"
       />
       <rect
-        x={80}
-        y={56}
+        x={107}
+        y={106}
         width={40}
         height={3}
         rx={1.5}
         fill="var(--solid-900)"
-      />
-
-      <path
-        d="M185.5 45a.5.5 0 010 1h-105a.5.5 0 010-1h105zM185.5 80a.5.5 0 010 1h-105a.5.5 0 010-1h105z"
-        fill="var(--base-400)"
       />
     </svg>
   );


### PR DESCRIPTION
Tailblocks components are very awesome and simple to use. I really want to contribute to it.

This PR is regarding the addition of the 4th template of the `Team` block. The lineal pattern for representing team members is not present initially. Adding this template gives another better alternative in the `Teams Section`.

Attached are the screenshots of required pages.

**Team D - Light** 

![Screenshot from 2022-07-14 17-45-35](https://user-images.githubusercontent.com/35539313/178981202-b04f265c-832d-4b39-9d05-de8337f70723.png)

**Team D - Dark**

![Screenshot from 2022-07-14 17-45-05](https://user-images.githubusercontent.com/35539313/178981292-e57052cf-b00b-4cdc-88cf-3cc81264cb34.png)

**Team D - Icon in sidebar**

![Screenshot from 2022-07-14 17-45-50](https://user-images.githubusercontent.com/35539313/178981390-2e5f32bb-00e0-4951-aeee-23c9952e07f7.png)

I hope my contribution adds value to [tailblocks](https://tailblocks.cc/)