### PR TITLE
Adding missing stickers in Hero Template Icon

### DIFF
--- a/src/icons/hero/d.js
+++ b/src/icons/hero/d.js
@@ -5,12 +5,12 @@ function HeroD() {
     <svg viewBox="0 0 266 150" fill="none">
       <path fill="var(--solid)" d="M0 0h266v150H0z" />
       <path
-        d="M79 88a2 2 0 012-2h25a2 2 0 012 2v6a2 2 0 01-2 2H81a2 2 0 01-2-2v-6z"
+        d="M79 78a2 2 0 012-2h25a2 2 0 012 2v6a2 2 0 01-2 2H81a2 2 0 01-2-2v-6z"
         fill="var(--main-500)"
       />
       <rect
         x={20}
-        y={86}
+        y={76}
         width={55}
         height={10}
         rx={2}
@@ -18,21 +18,37 @@ function HeroD() {
       />
       <rect
         x={20}
-        y={64}
-        width={104}
+        y={60}
+        width={114}
         height={4}
         rx={2}
         fill="var(--base-500)"
       />
       <rect
         x={20}
-        y={53}
+        y={52}
         width={72}
         height={5}
         rx={2.5}
         fill="var(--solid-900)"
       />
-      <rect x={20} y={72} width={97} height={4} rx={2} fill="var(--base-500)" />
+      <rect x={20} y={65} width={20} height={4} rx={2} fill="var(--base-500)" />
+      <rect
+        x={53}
+        y={90}
+        width={30}
+        height={8}
+        rx={2}
+        fill="var(--base-400)"
+      />
+      <rect
+        x={20}
+        y={90}
+        width={30}
+        height={8}
+        rx={2}
+        fill="var(--base-400)"
+      />
       <path
         d="M176.778 92h26.444A3.778 3.778 0 00207 88.222V61.778A3.778 3.778 0 00203.222 58h-26.444A3.778 3.778 0 00173 61.778v26.444A3.778 3.778 0 00176.778 92zm0 0l20.778-20.778L207 80.667m-20.778-12.278a2.833 2.833 0 11-5.666 0 2.833 2.833 0 015.666 0z"
         stroke="var(--base-500)"

--- a/src/icons/hero/e.js
+++ b/src/icons/hero/e.js
@@ -1,16 +1,16 @@
-import React from "react"
+import React from "react";
 
 function HeroE() {
   return (
     <svg viewBox="0 0 266 150" fill="none">
       <path fill="var(--solid)" d="M0 0h266v150H0z" />
       <path
-        d="M192 88a2 2 0 012-2h25a2 2 0 012 2v6a2 2 0 01-2 2h-25a2 2 0 01-2-2v-6z"
+        d="M192 78a2 2 0 012-2h25a2 2 0 012 2v6a2 2 0 01-2 2h-25a2 2 0 01-2-2v-6z"
         fill="var(--main-500)"
       />
       <rect
         x={133}
-        y={86}
+        y={76}
         width={55}
         height={10}
         rx={2}
@@ -18,15 +18,15 @@ function HeroE() {
       />
       <rect
         x={133}
-        y={64}
-        width={104}
+        y={60}
+        width={114}
         height={4}
         rx={2}
         fill="var(--base-500)"
       />
       <rect
         x={133}
-        y={53}
+        y={52}
         width={72}
         height={5}
         rx={2.5}
@@ -34,11 +34,27 @@ function HeroE() {
       />
       <rect
         x={133}
-        y={72}
-        width={97}
+        y={65}
+        width={20}
         height={4}
         rx={2}
         fill="var(--base-500)"
+      />
+      <rect
+        x={166}
+        y={90}
+        width={30}
+        height={8}
+        rx={2}
+        fill="var(--base-400)"
+      />
+      <rect
+        x={133}
+        y={90}
+        width={30}
+        height={8}
+        rx={2}
+        fill="var(--base-400)"
       />
       <path
         d="M62.778 92h26.444A3.778 3.778 0 0093 88.222V61.778A3.778 3.778 0 0089.222 58H62.778A3.778 3.778 0 0059 61.778v26.444A3.778 3.778 0 0062.778 92zm0 0l20.778-20.778L93 80.667M72.222 68.389a2.833 2.833 0 11-5.666 0 2.833 2.833 0 015.666 0z"
@@ -48,7 +64,7 @@ function HeroE() {
         strokeLinejoin="round"
       />
     </svg>
-  )
+  );
 }
 
 export default HeroE;

--- a/src/icons/hero/f.js
+++ b/src/icons/hero/f.js
@@ -6,7 +6,7 @@ function HeroF() {
       <path fill="var(--solid)" d="M0 0h266v150H0z" />
       <rect
         x={81}
-        y={92}
+        y={87}
         width={104}
         height={4}
         rx={2}
@@ -14,19 +14,19 @@ function HeroF() {
       />
       <rect
         x={97}
-        y={81}
+        y={76}
         width={72}
         height={5}
         rx={2.5}
         fill="var(--solid-900)"
       />
       <path
-        d="M148 116a2 2 0 012-2h25a2 2 0 012 2v6a2 2 0 01-2 2h-25a2 2 0 01-2-2v-6z"
+        d="M148 111a2 2 0 012-2h25a2 2 0 012 2v6a2 2 0 01-2 2h-25a2 2 0 01-2-2v-6z"
         fill="var(--main-500)"
       />
       <rect
         x={89}
-        y={114}
+        y={109}
         width={55}
         height={10}
         rx={2}
@@ -34,11 +34,27 @@ function HeroF() {
       />
       <rect
         x={85}
-        y={100}
+        y={95}
         width={97}
         height={4}
         rx={2}
         fill="var(--base-500)"
+      />
+      <rect
+        x={130}
+        y={125}
+        width={30}
+        height={8}
+        rx={2}
+        fill="var(--base-400)"
+      />
+      <rect
+        x={98}
+        y={125}
+        width={30}
+        height={8}
+        rx={2}
+        fill="var(--base-400)"
       />
       <path
         d="M119.778 61h26.444A3.778 3.778 0 00150 57.222V30.778A3.778 3.778 0 00146.222 27h-26.444A3.778 3.778 0 00116 30.778v26.444A3.778 3.778 0 00119.778 61zm0 0l20.778-20.778L150 49.667m-20.778-12.278a2.833 2.833 0 11-5.666 0 2.833 2.833 0 015.666 0z"


### PR DESCRIPTION
**Title:** Representation of Stickers is Missing in the icons of Hero D, Hero E & Hero F Template

**Fixes:** #90 

**Description:** This PR is regarding the representation of stickers of Google Play Store and App Store is missing in the icons of `Hero D`, `Hero E` & `Hero F` Template. However, they are represented in the icon of `CTA-D` template.

**ScreenShot:**

**Before Hero-D template**
![Screenshot from 2022-07-15 16-14-11](https://user-images.githubusercontent.com/35539313/179208355-5b2cddf6-12c8-4794-8a5f-efb473997170.png)

**After Hero-D template**
![Screenshot from 2022-07-15 17-07-05](https://user-images.githubusercontent.com/35539313/179215929-9d3a758d-5a81-409a-82f7-bcc3b90f4af4.png)

> _As you can see, I had added a representation of stickers of Google Play Store and App Store that was earlier missing in Hero D template. Also, there's an extra line above, I had made it more similar to a real template too._


**Hero E template**
![Screenshot from 2022-07-15 19-18-57](https://user-images.githubusercontent.com/35539313/179236942-8a94b270-d685-41d7-a2fa-84f5daf579de.png)


**Hero F template**
![Screenshot from 2022-07-15 19-20-52](https://user-images.githubusercontent.com/35539313/179237017-f7c75b5e-ddfc-4da6-9d8e-d44816153543.png)


**What I had Done:**
It had represented them as done in the icon of the `CTA - D` template. See screenshots below/