### PR TITLE
Adding missing blockquotes in Testimonial C template

### DIFF
--- a/src/blocks/testimonial/dark/c.js
+++ b/src/blocks/testimonial/dark/c.js
@@ -13,13 +13,21 @@ function DarkTestimonialC(props) {
                 className="w-20 h-20 mb-8 object-cover object-center rounded-full inline-block border-2 border-gray-800 bg-gray-800 bg-opacity-10"
                 src="https://dummyimage.com/302x302"
               />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                className="block w-5 h-5 text-gray-500 mb-4 mx-auto"
+                viewBox="0 0 975.036 975.036"
+              >
+                <path d="M925.036 57.197h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.399 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l36 76c11.6 24.399 40.3 35.1 65.1 24.399 66.2-28.6 122.101-64.8 167.7-108.8 55.601-53.7 93.7-114.3 114.3-181.9 20.601-67.6 30.9-159.8 30.9-276.8v-239c0-27.599-22.401-50-50-50zM106.036 913.497c65.4-28.5 121-64.699 166.9-108.6 56.1-53.7 94.4-114.1 115-181.2 20.6-67.1 30.899-159.6 30.899-277.5v-239c0-27.6-22.399-50-50-50h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.4 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l35.9 75.8c11.601 24.399 40.501 35.2 65.301 24.399z" />
+              </svg>
               <p className="leading-relaxed">
                 Edison bulb retro cloud bread echo park, helvetica stumptown
                 taiyaki taxidermy 90&apos;s cronut +1 kinfolk. Single-origin
                 coffee ennui shaman taiyaki vape DIY tote bag drinking vinegar
                 cronut adaptogen squid fanny pack vaporware.
               </p>
-              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4`}></span>
+              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4 mx-auto`}></span>
               <h2 className="text-white font-medium title-font tracking-wider text-sm">
                 HOLDEN CAULFIELD
               </h2>
@@ -33,13 +41,21 @@ function DarkTestimonialC(props) {
                 className="w-20 h-20 mb-8 object-cover object-center rounded-full inline-block border-2 border-gray-800 bg-gray-800 bg-opacity-10"
                 src="https://dummyimage.com/300x300"
               />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                className="block w-5 h-5 text-gray-500 mb-4 mx-auto"
+                viewBox="0 0 975.036 975.036"
+              >
+                <path d="M925.036 57.197h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.399 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l36 76c11.6 24.399 40.3 35.1 65.1 24.399 66.2-28.6 122.101-64.8 167.7-108.8 55.601-53.7 93.7-114.3 114.3-181.9 20.601-67.6 30.9-159.8 30.9-276.8v-239c0-27.599-22.401-50-50-50zM106.036 913.497c65.4-28.5 121-64.699 166.9-108.6 56.1-53.7 94.4-114.1 115-181.2 20.6-67.1 30.899-159.6 30.899-277.5v-239c0-27.6-22.399-50-50-50h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.4 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l35.9 75.8c11.601 24.399 40.501 35.2 65.301 24.399z" />
+              </svg>
               <p className="leading-relaxed">
                 Edison bulb retro cloud bread echo park, helvetica stumptown
                 taiyaki taxidermy 90&apos;s cronut +1 kinfolk. Single-origin
                 coffee ennui shaman taiyaki vape DIY tote bag drinking vinegar
                 cronut adaptogen squid fanny pack vaporware.
               </p>
-              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4`}></span>
+              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4 mx-auto`}></span>
               <h2 className="text-white font-medium title-font tracking-wider text-sm">
                 ALPER KAMU
               </h2>
@@ -53,13 +69,21 @@ function DarkTestimonialC(props) {
                 className="w-20 h-20 mb-8 object-cover object-center rounded-full inline-block border-2 border-gray-800 bg-gray-800 bg-opacity-10"
                 src="https://dummyimage.com/305x305"
               />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                className="block w-5 h-5 text-gray-500 mb-4 mx-auto"
+                viewBox="0 0 975.036 975.036"
+              >
+                <path d="M925.036 57.197h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.399 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l36 76c11.6 24.399 40.3 35.1 65.1 24.399 66.2-28.6 122.101-64.8 167.7-108.8 55.601-53.7 93.7-114.3 114.3-181.9 20.601-67.6 30.9-159.8 30.9-276.8v-239c0-27.599-22.401-50-50-50zM106.036 913.497c65.4-28.5 121-64.699 166.9-108.6 56.1-53.7 94.4-114.1 115-181.2 20.6-67.1 30.899-159.6 30.899-277.5v-239c0-27.6-22.399-50-50-50h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.4 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l35.9 75.8c11.601 24.399 40.501 35.2 65.301 24.399z" />
+              </svg>
               <p className="leading-relaxed">
                 Edison bulb retro cloud bread echo park, helvetica stumptown
                 taiyaki taxidermy 90&apos;s cronut +1 kinfolk. Single-origin
                 coffee ennui shaman taiyaki vape DIY tote bag drinking vinegar
                 cronut adaptogen squid fanny pack vaporware.
               </p>
-              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4`}></span>
+              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4 mx-auto`}></span>
               <h2 className="text-white font-medium title-font tracking-wider text-sm">
                 HENRY LETHAM
               </h2>

--- a/src/blocks/testimonial/light/c.js
+++ b/src/blocks/testimonial/light/c.js
@@ -13,13 +13,21 @@ function LightTestimonialC(props) {
                 className="w-20 h-20 mb-8 object-cover object-center rounded-full inline-block border-2 border-gray-200 bg-gray-100"
                 src="https://dummyimage.com/302x302"
               />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                className="block w-5 h-5 text-gray-400 mb-4 mx-auto"
+                viewBox="0 0 975.036 975.036"
+              >
+                <path d="M935.036 57.197h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.399 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l36 76c11.6 24.399 40.3 35.1 65.1 24.399 66.2-28.6 122.101-64.8 167.7-108.8 55.601-53.7 93.7-114.3 114.3-181.9 20.601-67.6 30.9-159.8 30.9-276.8v-239c0-27.599-22.401-50-50-50zM106.036 913.497c65.4-28.5 121-64.699 166.9-108.6 56.1-53.7 94.4-114.1 115-181.2 20.6-67.1 30.899-159.6 30.899-277.5v-239c0-27.6-22.399-50-50-50h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.4 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l35.9 75.8c11.601 24.399 40.501 35.2 65.301 24.399z" />
+              </svg>
               <p className="leading-relaxed">
                 Edison bulb retro cloud bread echo park, helvetica stumptown
                 taiyaki taxidermy 90&apos;s cronut +1 kinfolk. Single-origin
                 coffee ennui shaman taiyaki vape DIY tote bag drinking vinegar
                 cronut adaptogen squid fanny pack vaporware.
               </p>
-              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4`}></span>
+              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4 mx-auto`}></span>
               <h2 className="text-gray-900 font-medium title-font tracking-wider text-sm">
                 HOLDEN CAULFIELD
               </h2>
@@ -33,13 +41,21 @@ function LightTestimonialC(props) {
                 className="w-20 h-20 mb-8 object-cover object-center rounded-full inline-block border-2 border-gray-200 bg-gray-100"
                 src="https://dummyimage.com/300x300"
               />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                className="block w-5 h-5 text-gray-400 mb-4 mx-auto"
+                viewBox="0 0 975.036 975.036"
+              >
+                <path d="M935.036 57.197h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.399 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l36 76c11.6 24.399 40.3 35.1 65.1 24.399 66.2-28.6 122.101-64.8 167.7-108.8 55.601-53.7 93.7-114.3 114.3-181.9 20.601-67.6 30.9-159.8 30.9-276.8v-239c0-27.599-22.401-50-50-50zM106.036 913.497c65.4-28.5 121-64.699 166.9-108.6 56.1-53.7 94.4-114.1 115-181.2 20.6-67.1 30.899-159.6 30.899-277.5v-239c0-27.6-22.399-50-50-50h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.4 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l35.9 75.8c11.601 24.399 40.501 35.2 65.301 24.399z" />
+              </svg>
               <p className="leading-relaxed">
                 Edison bulb retro cloud bread echo park, helvetica stumptown
                 taiyaki taxidermy 90&apos;s cronut +1 kinfolk. Single-origin
                 coffee ennui shaman taiyaki vape DIY tote bag drinking vinegar
                 cronut adaptogen squid fanny pack vaporware.
               </p>
-              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4`}></span>
+              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4 mx-auto`}></span>
               <h2 className="text-gray-900 font-medium title-font tracking-wider text-sm">
                 ALPER KAMU
               </h2>
@@ -53,13 +69,21 @@ function LightTestimonialC(props) {
                 className="w-20 h-20 mb-8 object-cover object-center rounded-full inline-block border-2 border-gray-200 bg-gray-100"
                 src="https://dummyimage.com/305x305"
               />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                className="block w-5 h-5 text-gray-400 mb-4 mx-auto"
+                viewBox="0 0 975.036 975.036"
+              >
+                <path d="M935.036 57.197h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.399 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l36 76c11.6 24.399 40.3 35.1 65.1 24.399 66.2-28.6 122.101-64.8 167.7-108.8 55.601-53.7 93.7-114.3 114.3-181.9 20.601-67.6 30.9-159.8 30.9-276.8v-239c0-27.599-22.401-50-50-50zM106.036 913.497c65.4-28.5 121-64.699 166.9-108.6 56.1-53.7 94.4-114.1 115-181.2 20.6-67.1 30.899-159.6 30.899-277.5v-239c0-27.6-22.399-50-50-50h-304c-27.6 0-50 22.4-50 50v304c0 27.601 22.4 50 50 50h145.5c-1.9 79.601-20.4 143.3-55.4 191.2-27.6 37.8-69.4 69.1-125.3 93.8-25.7 11.3-36.8 41.7-24.8 67.101l35.9 75.8c11.601 24.399 40.501 35.2 65.301 24.399z" />
+              </svg>
               <p className="leading-relaxed">
                 Edison bulb retro cloud bread echo park, helvetica stumptown
                 taiyaki taxidermy 90&apos;s cronut +1 kinfolk. Single-origin
                 coffee ennui shaman taiyaki vape DIY tote bag drinking vinegar
                 cronut adaptogen squid fanny pack vaporware.
               </p>
-              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4`}></span>
+              <span className={`inline-block h-1 w-10 rounded bg-${props.theme}-500 mt-6 mb-4 mx-auto`}></span>
               <h2 className="text-gray-900 font-medium title-font tracking-wider text-sm">
                 HENRY LETHAM
               </h2>

--- a/src/icons/testimonial/c.js
+++ b/src/icons/testimonial/c.js
@@ -20,7 +20,23 @@ function TestimonialC() {
         d="M44 94.5a1.5 1.5 0 011.5-1.5h13.38a1.5 1.5 0 010 3H45.5a1.5 1.5 0 01-1.5-1.5z"
         fill="var(--main-500)"
       />
-      <circle cx={53} cy={53} r={8} fill="var(--base-300)" />
+      <rect
+        x={49}
+        y={57}
+        width={2.5}
+        height={5}
+        rx={2.5}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={54}
+        y={57}
+        width={2.5}
+        height={5}
+        rx={2.5}
+        fill="var(--base-500)"
+      />
+      <circle cx={53} cy={45} r={8} fill="var(--base-300)" />
       <path
         d="M102 77a2 2 0 012-2h59a2 2 0 110 4h-59a2 2 0 01-2-2zM107 85a2 2 0 012-2h48.92a2 2 0 110 4H109a2 2 0 01-2-2z"
         fill="var(--base-500)"
@@ -37,7 +53,23 @@ function TestimonialC() {
         d="M125 94.5a1.5 1.5 0 011.5-1.5h13.38a1.5 1.5 0 010 3H126.5a1.5 1.5 0 01-1.5-1.5z"
         fill="var(--main-500)"
       />
-      <circle cx={134} cy={53} r={8} fill="var(--base-300)" />
+      <rect
+        x={130}
+        y={57}
+        width={2.5}
+        height={5}
+        rx={2.5}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={135}
+        y={57}
+        width={2.5}
+        height={5}
+        rx={2.5}
+        fill="var(--base-500)"
+      />
+      <circle cx={134} cy={45} r={8} fill="var(--base-300)" />
       <path
         d="M183 77a2 2 0 012-2h59a2 2 0 110 4h-59a2 2 0 01-2-2zM188 85a2 2 0 012-2h48.92a2 2 0 110 4H190a2 2 0 01-2-2z"
         fill="var(--base-500)"
@@ -54,7 +86,23 @@ function TestimonialC() {
         d="M206 94.5a1.5 1.5 0 011.5-1.5h13.38a1.5 1.5 0 010 3H207.5a1.5 1.5 0 01-1.5-1.5z"
         fill="var(--main-500)"
       />
-      <circle cx={215} cy={53} r={8} fill="var(--base-300)" />
+      <rect
+        x={211}
+        y={57}
+        width={2.5}
+        height={5}
+        rx={2.5}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={216}
+        y={57}
+        width={2.5}
+        height={5}
+        rx={2.5}
+        fill="var(--base-500)"
+      />
+      <circle cx={215} cy={45} r={8} fill="var(--base-300)" />
     </svg>
   )
 }


### PR DESCRIPTION
**Title:** Blockquote is not present in the Testimonial-C template

**Fixes:** #92 

**Description:** This PR is regarding the representation of Blockquote which is earlier not present in the Testimonial-C template (both in light & dark mode) . However, they are represented in the `A` and `B` templates of the same.

**ScreenShot:**

### **light mode**
**Before**
![Screenshot from 2022-07-16 15-54-30](https://user-images.githubusercontent.com/35539313/179351066-33550157-f13d-474e-849c-ddd5d727037a.png)

**After**
![Screenshot from 2022-07-16 16-33-53](https://user-images.githubusercontent.com/35539313/179352279-54b6e437-2ed8-4cd2-a394-52b3f59d36c6.png)


### **Dark mode**

**Before**
![Screenshot from 2022-07-16 15-53-57](https://user-images.githubusercontent.com/35539313/179351068-8c5b0d52-3402-4b54-afa4-a62e417986f7.png)

**After**
![Screenshot from 2022-07-16 16-27-45](https://user-images.githubusercontent.com/35539313/179352108-c684e725-35e0-411a-be57-2cd7760e3f25.png)


> _As you can see, I had added the blockquote in the required place in the Testimonial template._

**What to be Done:**

I had added the blockquote in the required place in the Testimonial template.