### PR TITLE
Enhancement: Addition of two FAQ templates

### DIFF
--- a/src/blocks/faq/dark/a.js
+++ b/src/blocks/faq/dark/a.js
@@ -1,0 +1,116 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function DarkFAQA(props) {
+  return (
+    <section className="text-gray-400 bg-gray-900 body-font overflow-hidden">
+      <div className="container px-5 py-24 mx-auto">
+        <div className="flex flex-wrap w-full mb-20 flex-col items-center text-center">
+          <h1 className="sm:text-3xl text-2xl font-medium title-font mb-2 text-white">
+            Frequently Asked Questions
+          </h1>
+          <p className="lg:w-1/2 w-full leading-relaxed text-opacity-80">
+            Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical.
+          </p>
+        </div>
+        <div className="-my-8 divide-y-2 divide-gray-800">
+          <div className="py-8 flex flex-wrap md:space-x-24 md:flex-nowrap">
+            <div className="md:w-16 p-2 md:mb-0 mb-6 bg-gray-800 items-center justify-center flex flex-col ">
+              <span
+                className={`text-gray-400 pb-2 mb-2 border-b-2 border-${props.theme}-200 text-xl`}
+              >
+                Ques
+              </span>
+              <span className="font-medium text-lg md:text-xl text-white title-font leading-none">
+                01
+              </span>
+            </div>
+            <div className="md:flex-grow">
+              <h2 className="text-2xl font-medium text-white title-font mb-2">
+                Bitters hashtag waistcoat fashion axe chia unicorn ?
+              </h2>
+              <p className="leading-relaxed">
+                Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft
+                beer.Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft beer.
+              </p>
+            </div>
+          </div>
+
+          <div className="py-8 flex flex-wrap md:space-x-24 md:flex-nowrap">
+            <div className="md:w-16 md:mb-0 p-2 mb-6 bg-gray-800 items-center justify-center flex flex-col ">
+              <span
+                className={`text-gray-400 pb-2 mb-2 border-b-2 border-${props.theme}-200 text-xl`}
+              >
+                Ques
+              </span>
+              <span className="font-medium text-lg md:text-xl text-white title-font leading-none">
+                02
+              </span>
+            </div>
+            <div className="md:flex-grow">
+              <h2 className="text-2xl font-medium text-white title-font mb-2">
+                Meditation bushwick direct trade taxidermy shaman ?
+              </h2>
+              <p className="leading-relaxed">
+                Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft
+                beer.Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft beer.
+              </p>
+            </div>
+          </div>
+
+          <div className="py-8 flex flex-wrap md:space-x-24 md:flex-nowrap">
+            <div className="md:w-16 md:mb-0 p-2 mb-6 bg-gray-800 items-center justify-center flex flex-col ">
+              <span
+                className={`text-gray-400 pb-2 mb-2 border-b-2 border-${props.theme}-200 text-xl`}
+              >
+                Ques
+              </span>
+              <span className="font-medium text-lg md:text-xl text-white title-font leading-none">
+                03
+              </span>
+            </div>
+            <div className="md:flex-grow">
+              <h2 className="text-2xl font-medium text-white title-font mb-2">
+                  Woke master cleanse drinking vinegar salvia ?
+              </h2>
+              <p className="leading-relaxed">
+                Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft
+                beer.Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft beer.
+              </p>
+            </div>
+          </div>
+
+          
+        </div>
+      </div>
+    </section>
+  );
+}
+
+DarkFAQA.defaultProps = {
+  theme: "indigo",
+};
+
+DarkFAQA.propTypes = {
+  theme: PropTypes.string.isRequired,
+};
+
+export default DarkFAQA;

--- a/src/blocks/faq/dark/b.js
+++ b/src/blocks/faq/dark/b.js
@@ -1,0 +1,132 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function DarkFAQB(props) {
+  return (
+    <section className="text-gray-400 bg-gray-900 body-font">
+      <div className="container px-5 py-24 mx-auto">
+        <div className="flex flex-wrap w-full mb-20 flex-col items-center text-center">
+          <h1 className="sm:text-3xl text-2xl font-medium title-font mb-2 text-white">
+            Frequently Asked Questions
+          </h1>
+          <p className="lg:w-1/2 w-full leading-relaxed text-opacity-80">
+            Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical.
+          </p>
+        </div>
+        <div className="flex flex-wrap -m-4">
+          <div className="p-4 lg:w-1/3">
+            <div className="h-full bg-gray-800 bg-opacity-40 px-8 pt-16 pb-8 rounded-lg overflow-hidden text-center relative">
+              <h2 className="tracking-widest text-xs title-font font-medium text-gray-500 mb-1">
+                QUESTION 1
+              </h2>
+              <h1 className="title-font text-left text-xl font-medium text-white mb-3">
+                Pinterest DIY dreamcatcher gentrify single-origin coffee ?
+              </h1>
+              <p className="leading-relaxed mb-3 text-justify">
+                Photo booth fam kinfolk cold-pressed sriracha leggings jianbing
+                microdosing tousled waistcoat. Plaid fixie chambray 90's,
+                slow-carb etsy tumeric. Cray pug you probably haven't heard of
+                them.
+              </p>
+              <a
+                href
+                className={`text-${props.theme}-400 flex items-center justify-start`}
+              >
+                Learn More
+                <svg
+                  className="w-4 h-4 ml-2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div className="p-4 lg:w-1/3">
+            <div className="h-full bg-gray-800 bg-opacity-40 px-8 pt-16 pb-8 rounded-lg overflow-hidden text-center relative">
+              <h2 className="tracking-widest text-xs title-font font-medium text-gray-500 mb-1">
+                QUESTION 2
+              </h2>
+              <h1 className="title-font text-left text-xl font-medium text-white mb-3">
+                Ennui Snackwave Thundercats Hotplace SuperSonic ?
+              </h1>
+              <p className="leading-relaxed mb-3 text-justify">
+                Live-edge letterpress cliche, salvia fanny pack humblebrag
+                narwhal portland. VHS man braid palo santo hoodie brunch trust
+                fund. Bitters hashtag waistcoat fashion axe chia unicorn.
+              </p>
+              <a
+                href
+                className={`text-${props.theme}-400 flex items-center justify-start`}
+              >
+                Learn More
+                <svg
+                  className="w-4 h-4 ml-2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div className="p-4 lg:w-1/3">
+            <div className="h-full bg-gray-800 bg-opacity-40 px-8 pt-16 pb-8 rounded-lg overflow-hidden text-center relative">
+              <h2 className="tracking-widest text-xs title-font font-medium text-gray-500 mb-1">
+                QUESTION 3
+              </h2>
+              <h1 className="title-font text-left text-xl font-medium text-white mb-3">
+                Roof party normcore before they sold out, cornhole vape ?
+              </h1>
+              <p className="leading-relaxed mb-3 text-justify">
+                Franzen you probably haven't heard of them man bun deep jianbing
+                selfies heirloom prism food truck ugh squid celiac humblebrag.
+                Cold-pressed sriracha leggings jianbing microdosing tousled
+                waistcoat.
+              </p>
+              <a
+                href
+                className={`text-${props.theme}-400 flex items-center justify-start`}
+              >
+                Learn More
+                <svg
+                  className="w-4 h-4 ml-2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+DarkFAQB.defaultProps = {
+  theme: "indigo",
+};
+
+DarkFAQB.propTypes = {
+  theme: PropTypes.string.isRequired,
+};
+
+export default DarkFAQB;

--- a/src/blocks/faq/light/a.js
+++ b/src/blocks/faq/light/a.js
@@ -1,0 +1,116 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function LightFAQA(props) {
+  return (
+    <section className="text-gray-600 body-font overflow-hidden">
+      <div className="container px-5 py-24 mx-auto">
+        <div className="flex flex-wrap w-full mb-20 flex-col items-center text-center">
+          <h1 className="sm:text-3xl text-2xl font-medium title-font mb-2 text-gray-900">
+            Frequently Asked Questions
+          </h1>
+          <p className="lg:w-1/2 w-full leading-relaxed text-gray-500">
+            Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical.
+          </p>
+        </div>
+        <div className="-my-8 divide-y-2 divide-gray-100">
+          <div className="py-8 flex flex-wrap md:space-x-24 md:flex-nowrap">
+            <div className="md:w-16 p-2 md:mb-0 mb-6 bg-gray-100 items-center justify-center flex flex-col ">
+              <span
+                className={`text-gray-500 pb-2 mb-2 border-b-2 border-${props.theme}-200 text-xl`}
+              >
+                Ques
+              </span>
+              <span className="font-medium text-lg md:text-xl text-gray-800 title-font leading-none">
+                01
+              </span>
+            </div>
+            <div className="md:flex-grow">
+              <h2 className="text-2xl font-medium text-gray-900 title-font mb-2">
+                Bitters hashtag waistcoat fashion axe chia unicorn ?
+              </h2>
+              <p className="leading-relaxed">
+                Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft
+                beer.Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft beer.
+              </p>
+            </div>
+          </div>
+
+          <div className="py-8 flex flex-wrap md:space-x-24 md:flex-nowrap">
+            <div className="md:w-16 md:mb-0 p-2 mb-6 bg-gray-100 items-center justify-center flex flex-col ">
+              <span
+                className={`text-gray-500 pb-2 mb-2 border-b-2 border-${props.theme}-200 text-xl`}
+              >
+                Ques
+              </span>
+              <span className="font-medium text-lg md:text-xl text-gray-800 title-font leading-none">
+                02
+              </span>
+            </div>
+            <div className="md:flex-grow">
+              <h2 className="text-2xl font-medium text-gray-900 title-font mb-2">
+                Meditation bushwick direct trade taxidermy shaman ?
+              </h2>
+              <p className="leading-relaxed">
+                Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft
+                beer.Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft beer.
+              </p>
+            </div>
+          </div>
+
+          <div className="py-8 flex flex-wrap md:space-x-24 md:flex-nowrap">
+            <div className="md:w-16 md:mb-0 p-2 mb-6 bg-gray-100 items-center justify-center flex flex-col ">
+              <span
+                className={`text-gray-500 pb-2 mb-2 border-b-2 border-${props.theme}-200 text-xl`}
+              >
+                Ques
+              </span>
+              <span className="font-medium text-lg md:text-xl text-gray-800 title-font leading-none">
+                03
+              </span>
+            </div>
+            <div className="md:flex-grow">
+              <h2 className="text-2xl font-medium text-gray-900 title-font mb-2">
+                  Woke master cleanse drinking vinegar salvia ?
+              </h2>
+              <p className="leading-relaxed">
+                Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft
+                beer.Glossier echo park pug, church-key sartorial biodiesel
+                vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon
+                party messenger bag selfies, poke vaporware kombucha
+                lumbersexual pork belly polaroid hoodie portland craft beer.
+              </p>
+            </div>
+          </div>
+
+          
+        </div>
+      </div>
+    </section>
+  );
+}
+
+LightFAQA.defaultProps = {
+  theme: "indigo",
+};
+
+LightFAQA.propTypes = {
+  theme: PropTypes.string.isRequired,
+};
+
+export default LightFAQA;

--- a/src/blocks/faq/light/b.js
+++ b/src/blocks/faq/light/b.js
@@ -1,0 +1,132 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function LightFAQB(props) {
+  return (
+    <section className="text-gray-600 body-font">
+      <div className="container px-5 py-24 mx-auto">
+        <div className="flex flex-wrap w-full mb-20 flex-col items-center text-center">
+          <h1 className="sm:text-3xl text-2xl font-medium title-font mb-2 text-gray-900">
+            Frequently Asked Questions
+          </h1>
+          <p className="lg:w-1/2 w-full leading-relaxed text-gray-500">
+            Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical.
+          </p>
+        </div>
+        <div className="flex flex-wrap -m-4">
+          <div className="p-4 lg:w-1/3">
+            <div className="h-full bg-gray-100 bg-opacity-75 px-8 pt-16 pb-8 rounded-lg overflow-hidden text-center relative">
+              <h2 className="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">
+                QUESTION 1
+              </h2>
+              <h1 className="title-font text-left text-xl font-medium text-gray-900 mb-3">
+                Pinterest DIY dreamcatcher gentrify single-origin coffee ?
+              </h1>
+              <p className="leading-relaxed mb-3 text-justify">
+                Photo booth fam kinfolk cold-pressed sriracha leggings jianbing
+                microdosing tousled waistcoat.Plaid fixie chambray 90's,
+                slow-carb etsy tumeric. Cray pug you probably haven't heard of
+                them.
+              </p>
+              <a
+                href
+                className={`text-${props.theme}-500 flex items-center justify-start`}
+              >
+                Learn More
+                <svg
+                  className="w-4 h-4 ml-2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div className="p-4 lg:w-1/3">
+            <div className="h-full bg-gray-100 bg-opacity-75 px-8 pt-16 pb-8 rounded-lg overflow-hidden text-center relative">
+              <h2 className="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">
+                QUESTION 2
+              </h2>
+              <h1 className="title-font text-left text-xl font-medium text-gray-900 mb-3">
+                Ennui Snackwave Thundercats Hotplace SuperSonic ?
+              </h1>
+              <p className="leading-relaxed mb-3 text-justify">
+                Live-edge letterpress cliche, salvia fanny pack humblebrag
+                narwhal portland. VHS man braid palo santo hoodie brunch trust
+                fund. Bitters hashtag waistcoat fashion axe chia unicorn.
+              </p>
+              <a
+                href
+                className={`text-${props.theme}-500 flex items-center justify-start`}
+              >
+                Learn More
+                <svg
+                  className="w-4 h-4 ml-2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div className="p-4 lg:w-1/3">
+            <div className="h-full bg-gray-100 bg-opacity-75 px-8 pt-16 pb-8 rounded-lg overflow-hidden text-center relative">
+              <h2 className="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">
+                QUESTION 3
+              </h2>
+              <h1 className="title-font text-left text-xl font-medium text-gray-900 mb-3">
+                Roof party normcore before they sold out, cornhole vape ?
+              </h1>
+              <p className="leading-relaxed mb-3 text-justify">
+                Franzen you probably haven't heard of them man bun deep jianbing
+                selfies heirloom prism food truck ugh squid celiac humblebrag.
+                Cold-pressed sriracha leggings jianbing microdosing tousled
+                waistcoat.
+              </p>
+              <a
+                href
+                className={`text-${props.theme}-500 flex items-center justify-start`}
+              >
+                Learn More
+                <svg
+                  className="w-4 h-4 ml-2"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M5 12h14" />
+                  <path d="M12 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+LightFAQB.defaultProps = {
+  theme: "indigo",
+};
+
+LightFAQB.propTypes = {
+  theme: PropTypes.string.isRequired,
+};
+
+export default LightFAQB;

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -57,8 +57,10 @@ import DarkEcommerceB from './ecommerce/dark/b';
 import DarkEcommerceC from './ecommerce/dark/c';
 
 import LightFAQA from './faq/light/a';
+import LightFAQB from './faq/light/b';
 
 import DarkFAQA from './faq/dark/a';
+import DarkFAQB from './faq/dark/b';
 
 import LightFeatureA from './feature/light/a';
 import LightFeatureB from './feature/light/b';
@@ -197,6 +199,7 @@ export default function getBlock({theme = 'indigo', darkMode = false}) {
     },
     FAQ: {
       FAQA: darkMode ? <DarkFAQA theme={theme} /> : <LightFAQA theme={theme} />,
+      FAQB: darkMode ? <DarkFAQB theme={theme} /> : <LightFAQB theme={theme} />
     },
     Feature: {
       FeatureA: darkMode ? <DarkFeatureA theme={theme} /> : <LightFeatureA theme={theme} />,

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -56,6 +56,9 @@ import DarkEcommerceA from './ecommerce/dark/a';
 import DarkEcommerceB from './ecommerce/dark/b';
 import DarkEcommerceC from './ecommerce/dark/c';
 
+import LightFAQA from './faq/light/a';
+
+import DarkFAQA from './faq/dark/a';
 
 import LightFeatureA from './feature/light/a';
 import LightFeatureB from './feature/light/b';
@@ -191,6 +194,9 @@ export default function getBlock({theme = 'indigo', darkMode = false}) {
       EcommerceA: darkMode ? <DarkEcommerceA theme={theme} /> : <LightEcommerceA theme={theme} />,
       EcommerceB: darkMode ? <DarkEcommerceB theme={theme} /> : <LightEcommerceB theme={theme} />,
       EcommerceC: darkMode ? <DarkEcommerceC theme={theme} /> : <LightEcommerceC theme={theme} />
+    },
+    FAQ: {
+      FAQA: darkMode ? <DarkFAQA theme={theme} /> : <LightFAQA theme={theme} />,
     },
     Feature: {
       FeatureA: darkMode ? <DarkFeatureA theme={theme} /> : <LightFeatureA theme={theme} />,

--- a/src/icons/faq/a.js
+++ b/src/icons/faq/a.js
@@ -1,0 +1,132 @@
+import React from "react";
+
+function FAQA() {
+  return (
+    <svg viewBox="0 0 266 150" fill="none">
+      <path fill="var(--solid)" d="M0 0h266v150H0z" />
+      <rect
+        x={81}
+        y={28}
+        width={90.732}
+        height={4}
+        rx={2}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={96}
+        y={20}
+        width={64}
+        height={5}
+        rx={2.5}
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={54}
+        y={49}
+        width={70}
+        height={4}
+        rx={2.5}
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={54}
+        y={57}
+        width={165}
+        height={3}
+        rx={1.5}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={24}
+        y={50}
+        width={12}
+        height={10}
+        rx={1}
+        fill="var(--base-200)"
+      />
+      <rect
+        x={54}
+        y={64}
+        width={129}
+        height={3}
+        rx={1.5}
+        fill="var(--base-500)"
+      />
+      <path
+        d="M245.5 78a.5.5 0 010 1h-225a.5.5 0 010-1h225z"
+        fill="var(--base-300)"
+      />
+      <path
+        d="M245.5 113a.5.5 0 010 1h-225a.5.5 0 010-1h225z"
+        fill="var(--base-300)"
+      />
+      <rect
+        x={54}
+        y={87}
+        width={70}
+        height={4}
+        rx={2.5}
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={54}
+        y={95}
+        width={165}
+        height={3}
+        rx={1.5}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={24}
+        y={92}
+        width={12}
+        height={10}
+        rx={1}
+        fill="var(--base-200)"
+      />
+      <rect
+        x={54}
+        y={101}
+        width={129}
+        height={3}
+        rx={1.5}
+        fill="var(--base-500)"
+      />
+
+      <rect
+        x={54}
+        y={120}
+        width={70}
+        height={4}
+        rx={2.5}
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={54}
+        y={128}
+        width={165}
+        height={3}
+        rx={1.5}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={24}
+        y={125}
+        width={12}
+        height={10}
+        rx={1}
+        fill="var(--base-200)"
+      />
+      <rect
+        x={54}
+        y={134}
+        width={129}
+        height={3}
+        rx={1.5}
+        fill="var(--base-500)"
+      />
+    </svg>
+  );
+}
+
+export default FAQA;

--- a/src/icons/faq/b.js
+++ b/src/icons/faq/b.js
@@ -1,0 +1,87 @@
+import React from "react";
+
+function FAQB() {
+  return (
+    <svg viewBox="0 0 266 150" fill="none">
+      <path fill="var(--solid)" d="M0 0h266v150H0z" />
+      <rect
+        x={91}
+        y={28}
+        width={90.732}
+        height={4}
+        rx={2}
+        fill="var(--base-500)"
+      />
+      <rect
+        x={106}
+        y={20}
+        width={64}
+        height={5}
+        rx={2.5}
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={20}
+        y={43}
+        width={68}
+        height={63}
+        rx={2}
+        fill="var(--base-200)"
+      />
+      <path
+        d="M29 73a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1zM29 78a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1zM29 83a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1z"
+        fill="var(--base-500)"
+      />
+      <path
+        d="M32 91a1 1 0 011-1h11a1 1 0 010 2h-11a1 1 0 01-1-1z"
+        fill="var(--main-500)"
+      />
+      <path
+        d="M32 67.5a1.5 1.5 0 011.5-1.5h32a1.5 1.5 0 010 3h-32a1.5 1.5 0 01-1.5-1.5z"
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={99}
+        y={43}
+        width={68}
+        height={63}
+        rx={2}
+        fill="var(--base-200)"
+      />
+      <path
+        d="M108 73a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1zM108 78a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1zM108 83a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1z"
+        fill="var(--base-500)"
+      />
+      <path
+        d="M111 91a1 1 0 011-1h11a1 1 0 010 2h-11a1 1 0 01-1-1z"
+        fill="var(--main-500)"
+      />
+      <path
+        d="M108 67.5a1.5 1.5 0 011.5-1.5h32a1.5 1.5 0 010 3h-32a1.5 1.5 0 01-1.5-1.5z"
+        fill="var(--solid-900)"
+      />
+      <rect
+        x={178}
+        y={43}
+        width={68}
+        height={63}
+        rx={2}
+        fill="var(--base-200)"
+      />
+      <path
+        d="M187 73a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1zM187 78a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1zM187 83a1 1 0 011-1h48a1 1 0 010 2h-48a1 1 0 01-1-1z"
+        fill="var(--base-500)"
+      />
+      <path
+        d="M190 91a1 1 0 011-1h11a1 1 0 010 2h-11a1 1 0 01-1-1z"
+        fill="var(--main-500)"
+      />
+      <path
+        d="M187 67.5a1.5 1.5 0 011.5-1.5h32a1.5 1.5 0 010 3h-32a1.5 1.5 0 01-1.5-1.5z"
+        fill="var(--solid-900)"
+      />
+    </svg>
+  );
+}
+
+export default FAQB;

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -28,6 +28,8 @@ import EcommerceA from './ecommerce/a';
 import EcommerceB from './ecommerce/b';
 import EcommerceC from './ecommerce/c';
 
+import FAQA from './faq/a';
+
 import FeatureA from './feature/a';
 import FeatureB from './feature/b';
 import FeatureC from './feature/c';
@@ -112,6 +114,9 @@ export default function getIcons() {
       EcommerceA: <EcommerceA />,
       EcommerceB: <EcommerceB />,
       EcommerceC: <EcommerceC />
+    },
+    FAQ: {
+      FAQA: <FAQA />
     },
     Feature: {
       FeatureA: <FeatureA />,

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -29,6 +29,7 @@ import EcommerceB from './ecommerce/b';
 import EcommerceC from './ecommerce/c';
 
 import FAQA from './faq/a';
+import FAQB from './faq/b';
 
 import FeatureA from './feature/a';
 import FeatureB from './feature/b';
@@ -116,7 +117,8 @@ export default function getIcons() {
       EcommerceC: <EcommerceC />
     },
     FAQ: {
-      FAQA: <FAQA />
+      FAQA: <FAQA />,
+      FAQB: <FAQB />
     },
     Feature: {
       FeatureA: <FeatureA />,


### PR DESCRIPTION
**Title:** Addition of two FAQ templates

**Fixes:** #52 

**Description:** This PR is regarding the addition of FAQ templates. Initially, I am adding two templates named `FAQA` and `FAQB`. If this PR gets merged, I'll add more templates in continuation.

**ScreenShot:**

### Template1 - FAQA

**Light mode**
![Screenshot from 2022-07-18 20-37-28](https://user-images.githubusercontent.com/35539313/179742772-b6410e92-0d7c-49e5-b296-0bf0c7d47beb.png)



**Dark mode**
![Screenshot from 2022-07-18 20-37-44](https://user-images.githubusercontent.com/35539313/179742790-1287bd2a-aa18-4b8e-bd52-6c73c25127fa.png)



### Template2 - FAQB

**Light mode**
![Screenshot from 2022-07-19 17-06-52](https://user-images.githubusercontent.com/35539313/179742904-b5b2b16d-9148-4df5-9574-707e5ce12ab1.png)




**Dark mode**

![Screenshot from 2022-07-19 17-07-09](https://user-images.githubusercontent.com/35539313/179742932-27c137d9-8018-4331-a442-c4f82b55d084.png)


> _As you can see, I had added the two FAQ templates._

This fixes #52 Request. 