### PR TITLE
Fixing the footer at the bottom

### DIFF
--- a/src/blocks/footer/dark/a.js
+++ b/src/blocks/footer/dark/a.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function DarkFooterA(props) {
   return (
-    <footer className="text-gray-400 bg-gray-900 body-font">
+    <footer className="text-gray-400 md:fixed md:bottom-14 md:left-0 md:w-screen bg-gray-900 body-font">
       <div className="container px-5 py-24 mx-auto flex md:items-center lg:items-start md:flex-row md:flex-nowrap flex-wrap flex-col">
         <div className="w-64 flex-shrink-0 md:mx-0 mx-auto text-center md:text-left">
           <a href className="flex title-font font-medium items-center md:justify-start justify-center text-white">

--- a/src/blocks/footer/dark/b.js
+++ b/src/blocks/footer/dark/b.js
@@ -4,7 +4,7 @@ import PropTypes from  "prop-types";
 
 function DarkFooterB(props) {
   return (
-    <footer className="text-gray-400 bg-gray-900 body-font">
+    <footer className="text-gray-400 md:fixed md:bottom-14 md:left-0 md:w-screen bg-gray-900 body-font">
       <div className="container px-5 py-24 mx-auto flex md:items-center lg:items-start md:flex-row md:flex-nowrap flex-wrap flex-col">
         <div className="w-64 flex-shrink-0 md:mx-0 mx-auto text-center md:text-left md:mt-0 mt-10">
           <a href className="flex title-font font-medium items-center md:justify-start justify-center text-white">

--- a/src/blocks/footer/dark/c.js
+++ b/src/blocks/footer/dark/c.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function DarkFooterC(props) {
   return (
-    <footer className="text-gray-400 bg-gray-900 body-font">
+    <footer className="text-gray-400 bg-gray-900 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-24 mx-auto">
         <div className="flex flex-wrap md:text-left text-center -mb-10 -mx-4">
           <div className="lg:w-1/6 md:w-1/2 w-full px-4">

--- a/src/blocks/footer/dark/d.js
+++ b/src/blocks/footer/dark/d.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function DarkFooterD(props) {
   return (
-    <footer className="text-gray-400 bg-gray-900 body-font">
+    <footer className="text-gray-400 bg-gray-900 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-8 mx-auto flex items-center sm:flex-row flex-col">
         <a href className="flex title-font font-medium items-center md:justify-start justify-center text-white">
           <svg

--- a/src/blocks/footer/dark/e.js
+++ b/src/blocks/footer/dark/e.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function DarkFooterE(props) {
   return (
-    <footer className="text-gray-400 bg-gray-900 body-font">
+    <footer className="text-gray-400 bg-gray-900 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-24 mx-auto">
         <div className="flex flex-wrap md:text-left text-center order-first">
           <div className="lg:w-1/4 md:w-1/2 w-full px-4">

--- a/src/blocks/footer/light/a.js
+++ b/src/blocks/footer/light/a.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function LightFooterA(props) {
   return (
-    <footer className="text-gray-600 body-font">
+    <footer className="text-gray-600 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-24 mx-auto flex md:items-center lg:items-start md:flex-row md:flex-nowrap flex-wrap flex-col">
         <div className="w-64 flex-shrink-0 md:mx-0 mx-auto text-center md:text-left">
           <a href className="flex title-font font-medium items-center md:justify-start justify-center text-gray-900">

--- a/src/blocks/footer/light/b.js
+++ b/src/blocks/footer/light/b.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function LightFooterB(props) {
   return (
-    <footer className="text-gray-600 body-font">
+    <footer className="text-gray-600 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-24 mx-auto flex md:items-center lg:items-start md:flex-row md:flex-nowrap flex-wrap flex-col">
         <div className="w-64 flex-shrink-0 md:mx-0 mx-auto text-center md:text-left md:mt-0 mt-10">
           <a href className="flex title-font font-medium items-center md:justify-start justify-center text-gray-900">

--- a/src/blocks/footer/light/c.js
+++ b/src/blocks/footer/light/c.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function LightFooterC(props) {
   return (
-    <footer className="text-gray-600 body-font">
+    <footer className="text-gray-600 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-24 mx-auto">
         <div className="flex flex-wrap md:text-left text-center -mb-10 -mx-4">
           <div className="lg:w-1/6 md:w-1/2 w-full px-4">

--- a/src/blocks/footer/light/d.js
+++ b/src/blocks/footer/light/d.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function LightFooterD(props) {
   return (
-    <footer className="text-gray-600 body-font">
+    <footer className="text-gray-600 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-8 mx-auto flex items-center sm:flex-row flex-col">
         <a href className="flex title-font font-medium items-center md:justify-start justify-center text-gray-900">
           <svg

--- a/src/blocks/footer/light/e.js
+++ b/src/blocks/footer/light/e.js
@@ -3,7 +3,7 @@ import PropTypes from  "prop-types";
 
 function LightFooterE(props) {
   return (
-    <footer className="text-gray-600 body-font">
+    <footer className="text-gray-600 md:fixed md:bottom-14 md:left-0 md:w-screen body-font">
       <div className="container px-5 py-24 mx-auto">
         <div className="flex flex-wrap md:text-left text-center order-first">
           <div className="lg:w-1/4 md:w-1/2 w-full px-4">


### PR DESCRIPTION
**Title:** Blockquote is not present in the Testimonial-C template

**Fixes:** #95 

**Description:** This PR is regarding (#95 ) the position of the footer which is earlier not present at the bottom in all the `Footer` templates (both in light & dark mode).

**What I Had Done:**

I had fixed the footer at the bottom in all the `Footer` templates. I had also given some bottom margin so that the arrows & GitHub logo on the right-bottom corner should not get overlapped with the footer.


**ScreenShot:**

### **Dark mode**

**Before**
![Screenshot from 2022-07-20 16-03-33](https://user-images.githubusercontent.com/35539313/179965158-34bacfe8-3766-433f-93e8-4957661ae7c6.png)


**After**

![Screenshot from 2022-07-20 16-15-51](https://user-images.githubusercontent.com/35539313/179965184-401b5706-629e-48e0-aa7c-58b6fad9d244.png)

> _As you can see, I had fixed the footer at the bottom in all the `Footer` templates._

**Some more templates**:

**FooterB**
![Screenshot from 2022-07-20 16-16-06](https://user-images.githubusercontent.com/35539313/179965621-c7623b92-f340-47a1-aca8-af37fe5f1406.png)

**FooterE**

![Screenshot from 2022-07-20 16-16-19](https://user-images.githubusercontent.com/35539313/179965687-678ba70e-d630-45f0-b514-d35e993a18b0.png)


